### PR TITLE
docs(warnings): Remove warnings related to documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: Artistic-2.0
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 biocViews: MassSpectrometry, Proteomics, Software, DataImport, QualityControl
 Depends:
     R (>= 4.0)

--- a/R/MSstatsConvert_core_functions.R
+++ b/R/MSstatsConvert_core_functions.R
@@ -95,6 +95,10 @@ setGeneric("getInputFile",
 setMethod("getInputFile", "MSstatsInputFiles", 
           function(msstats_object, file_type = "input") 
               msstats_object@files[[file_type]])
+#' @param msstats_object object that inherits from `MSstatsPhilosopherFiles` class.
+#' @param file_type character name of a type file. Usually equal to "input".
+#' @return data.table
+#' @rdname getInputFile
 setMethod("getInputFile", "MSstatsPhilosopherFiles",
           function(msstats_object, file_type = "input") {
               if (file_type == "annotation") {

--- a/R/clean_Philosopher.R
+++ b/R/clean_Philosopher.R
@@ -2,7 +2,7 @@
 #' @param msstats_object object of class MSstatsPhilosopherFiles
 #' @param protein_id_col character name of a column that identifies proteins
 #' @param peptide_id_col character name of a column that identifies peptides
-#' @param channel character vector of channel labels
+#' @param channels character vector of channel labels
 #' @param remove_shared_peptides logical, if TRUE, shared peptides will be 
 #' removed based on the IsUnique column from Philosopher output
 #' @keywords internal

--- a/R/utils_classes.R
+++ b/R/utils_classes.R
@@ -16,16 +16,18 @@ setOldClass("MSstatsValidated", S4Class = "MSstatsValidated")
 
 #' Convert output of converters to data.frame
 #' @param x object of class MSstatsValidated
+#' @param ... Additional arguments to be passed to or from other methods.
 #' @return data.frame
 #' @export
-as.data.frame.MSstatsValidated = function(x) {
+as.data.frame.MSstatsValidated = function(x, ...) {
   as.data.frame(unclass(x))
 }
 
 #' Convert output of converters to data.table
 #' @param x object of class MSstatsValidated
+#' @param ... Additional arguments to be passed to or from other methods.
 #' @return data.tables
 #' @export
-as.data.table.MSstatsValidated = function(x) {
+as.data.table.MSstatsValidated = function(x, ...) {
   data.table::as.data.table(unclass(x))
 }

--- a/man/MSstatsClean.Rd
+++ b/man/MSstatsClean.Rd
@@ -102,6 +102,8 @@ will be treated as corresponding to intensities for different channels.}
 
 \item{peptide_id_col}{character name of a column that identifies peptides}
 
+\item{channels}{character vector of channel labels}
+
 \item{remove_shared_peptides}{logical, if TRUE, shared peptides will be
 removed based on the IsUnique column from Philosopher output}
 

--- a/man/MSstatsConvert.Rd
+++ b/man/MSstatsConvert.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/utils_MSstatsConvert.R
 \docType{package}
 \name{MSstatsConvert}
+\alias{MSstatsConvert-package}
 \alias{MSstatsConvert}
 \title{MSstatsConvert: An R Package to Convert Data from Mass Spectrometry Signal Processing Tools to MSstats Format}
 \description{
@@ -17,3 +18,14 @@ signal processing tools to a format suitable for statistical analysis with the M
 \code{\link{MSstatsBalancedDesign}} for handling fractions and creating balanced data.
 }
 
+\author{
+\strong{Maintainer}: Mateusz Staniak \email{mtst@mstaniak.pl}
+
+Authors:
+\itemize{
+  \item Meena Choi \email{mnchoi67@gmail.com}
+  \item Ting Huang \email{thuang0703@gmail.com}
+  \item Olga Vitek \email{o.vitek@northeastern.edu}
+}
+
+}

--- a/man/as.data.frame.MSstatsValidated.Rd
+++ b/man/as.data.frame.MSstatsValidated.Rd
@@ -4,10 +4,12 @@
 \alias{as.data.frame.MSstatsValidated}
 \title{Convert output of converters to data.frame}
 \usage{
-\method{as.data.frame}{MSstatsValidated}(x)
+\method{as.data.frame}{MSstatsValidated}(x, ...)
 }
 \arguments{
 \item{x}{object of class MSstatsValidated}
+
+\item{...}{Additional arguments to be passed to or from other methods.}
 }
 \value{
 data.frame

--- a/man/as.data.table.MSstatsValidated.Rd
+++ b/man/as.data.table.MSstatsValidated.Rd
@@ -4,10 +4,12 @@
 \alias{as.data.table.MSstatsValidated}
 \title{Convert output of converters to data.table}
 \usage{
-\method{as.data.table}{MSstatsValidated}(x)
+\method{as.data.table}{MSstatsValidated}(x, ...)
 }
 \arguments{
 \item{x}{object of class MSstatsValidated}
+
+\item{...}{Additional arguments to be passed to or from other methods.}
 }
 \value{
 data.tables

--- a/man/dot-cleanRawPhilosopher.Rd
+++ b/man/dot-cleanRawPhilosopher.Rd
@@ -19,10 +19,10 @@
 
 \item{peptide_id_col}{character name of a column that identifies peptides}
 
+\item{channels}{character vector of channel labels}
+
 \item{remove_shared_peptides}{logical, if TRUE, shared peptides will be
 removed based on the IsUnique column from Philosopher output}
-
-\item{channel}{character vector of channel labels}
 }
 \value{
 data.table

--- a/man/getInputFile.Rd
+++ b/man/getInputFile.Rd
@@ -3,18 +3,23 @@
 \name{getInputFile}
 \alias{getInputFile}
 \alias{getInputFile,MSstatsInputFiles-method}
+\alias{getInputFile,MSstatsPhilosopherFiles-method}
 \title{Get one of files contained in an instance of \code{MSstatsInputFiles} class.}
 \usage{
 getInputFile(msstats_object, file_type)
 
 \S4method{getInputFile}{MSstatsInputFiles}(msstats_object, file_type = "input")
+
+\S4method{getInputFile}{MSstatsPhilosopherFiles}(msstats_object, file_type = "input")
 }
 \arguments{
-\item{msstats_object}{object that inherits from \code{MSstatsInputFiles} class.}
+\item{msstats_object}{object that inherits from \code{MSstatsPhilosopherFiles} class.}
 
 \item{file_type}{character name of a type file. Usually equal to "input".}
 }
 \value{
+data.table
+
 data.table
 
 data.table


### PR DESCRIPTION
# Motivation and Context

To make development easier, we should remove all existing warnings so that it's easy to spot if a change produced more warnings than before.  Also, these warnings are quick fixes related to missing documentation that should be addressed.

There are 3 warnings for this package:

```
❯ checking S3 generic/method consistency ... WARNING
  as.data.table:
    function(x, keep.rownames, ...)
  as.data.table.MSstatsValidated:
    function(x)
  
  as.data.frame:
    function(x, row.names, optional, ...)
  as.data.frame.MSstatsValidated:
    function(x)
  See section ‘Generic functions and methods’ in the ‘Writing R
  Extensions’ manual.

❯ checking for missing documentation entries ... WARNING
  Undocumented S4 methods:
    generic 'getInputFile' and siglist 'MSstatsPhilosopherFiles'
  All user-level objects in a package (including S4 classes and methods)
  should have documentation entries.
  See chapter ‘Writing R documentation files’ in the ‘Writing R
  Extensions’ manual.

❯ checking Rd \usage sections ... WARNING
  Undocumented arguments in documentation object 'MSstatsClean'
    ‘channels’
  
  Functions with \usage entries need to have the appropriate \alias
  entries, and all their arguments documented.
  The \usage entries must correspond to syntactically valid R code.
  See chapter ‘Writing R documentation files’ in the ‘Writing R
  Extensions’ manual.
```

## Changes
- Warning 1: Added `...` as a parameter for `as.data.table.MSstatsValidated` and `as.data.frame.MSstatsValidated` to make sure generic parameters matched method parameters.
- Warning 2: Added documentation for `getInputFile` where the input class is `MSstatsPhilosopherFiles`
- Warning 3: Fixed spelling error of parameter in documentation

## Testing
1. Ran `devtools::document()` and `devtools::check(document = FALSE)` and they both succeed.
2. [Dry Run Build](https://github.com/Vitek-Lab/MSstatsConvert/actions/runs/7574467198) produces 0 warnings

## Checklist Before Requesting a Review
- [x] I have read this repository's [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
