### PR TITLE
fix(skyline): Modified error message for Skyline outlining that MSstats only analyzes MS1 or MS2 but not both

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,6 @@ Please provide a detailed bullet point list of your changes.
 Please describe any unit tests you added or modified to verify your changes.
 
 ## Checklist Before Requesting a Review
-- [ ] I have read this repository's [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
+- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/workflows/dry-run-build.yml
+++ b/.github/workflows/dry-run-build.yml
@@ -1,7 +1,7 @@
 name: Dry runs for PRs
 on: 
   pull_request:
-    branches: [master]
+    branches: [devel]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/R/clean_Skyline.R
+++ b/R/clean_Skyline.R
@@ -76,9 +76,10 @@
     precursors = intersect(fragment_ions, 
                            c("precursor", "precursor [M+1]", "precursor [M+2]"))
     if (length(frags) > 0 & length(precursors) > 0) {
-        msg = paste("** Please check precursors information.",
-                    "If your experiment is DIA, please remove the precursors.",
-                    "If your experiments is DDA, please check the precursor information.")
+        msg = paste("** Please check precursors information in the FragmentIon column.",
+                    "If your experiment is DIA or SRM, please remove the precursors.",
+                    "If your experiments is DDA, please check the precursor information.",
+                    "MSstats only performs analysis on either MS1 or MS2, but not both simultaneously.")
         getOption("MSstatsLog")("ERROR", msg)
         stop(msg)
     }


### PR DESCRIPTION
# Motivation and Context

In this [Google group post](https://groups.google.com/g/msstats/c/MJkmEEX2J1U/m/9GwMWhuZAwAJ), the user got the below error message when they included both MS1 (precursor) and MS2 (fragment) ions in the FragmentIon column for an SRM experiment.

```
'Error in .checkDDA(input): **Please check precursors information. If your experiment is DIA, please remove the precursors. If your experiment is DDA, please check the precursor information.'
```

We should be more clear that MSstats does not analyze both MS1 and MS2 simultaneously.  We also need to point them to the FragmentIon column to make the fix and let them know what to do for the SRM scenario.

## Changes

Please provide a detailed bullet point list of your changes.

- Modified error message within the .checkDDA function that outlines that MSstats does not analyze both MS1 and MS2 simultaneously.  I also point the user to the FragmentIon column to make the fix and outlined that precursors should be removed for SRM.
- Minor: Update PR template & dry run build workflows

## Testing

Tested on the input file from the user and the error message is updated as expected.

## Checklist Before Requesting a Review
- [x] I have read this repository's [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
