### PR TITLE
Feature spec fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,6 +3,8 @@ Title: Import Data from Various Mass Spectrometry Signal Processing Tools to MSs
 Version: 1.15.1
 Authors@R: c(
   person("Mateusz", "Staniak", email = "mtst@mstaniak.pl", role = c("aut","cre")),
+  person("Devon", "Kohler", email = "kohler.d@northeastern.edu", role = "aut"),
+  person("Anthony", "Wu", email = "wu.anthon@northeastern.edu", role = "aut"),
   person("Meena", "Choi", email = "mnchoi67@gmail.com", role = "aut"),
   person("Ting", "Huang", email = "thuang0703@gmail.com", role = "aut"),
   person("Olga", "Vitek", , email = "o.vitek@northeastern.edu", role = "aut")) 
@@ -12,7 +14,7 @@ License: Artistic-2.0
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 biocViews: MassSpectrometry, Proteomics, Software, DataImport, QualityControl
 Depends:
     R (>= 4.0)

--- a/R/converters_SkylinetoMSstatsFormat.R
+++ b/R/converters_SkylinetoMSstatsFormat.R
@@ -66,7 +66,7 @@ SkylinetoMSstatsFormat = function(
                        score_threshold = qvalue_cutoff, 
                        direction = "smaller",
                        behavior = "fill", 
-                       fill_value = 0, 
+                       fill_value = NA_real_, 
                        handle_na = "keep",
                        filter = filter_with_Qvalue, 
                        drop_column = TRUE)
@@ -88,6 +88,8 @@ SkylinetoMSstatsFormat = function(
         feature_cleaning = list(
             remove_features_with_few_measurements = removeFewMeasurements,
             summarize_multiple_psms = sum))
+    input[, Intensity := ifelse(Intensity == 0, NA, Intensity)]
+    
     input = MSstatsBalancedDesign(input, c("PeptideSequence", "PrecursorCharge", 
                                            "FragmentIon", "ProductCharge"),
                                   remove_few = removeFewMeasurements)

--- a/R/converters_SpectronauttoMSstatsFormat.R
+++ b/R/converters_SpectronauttoMSstatsFormat.R
@@ -41,7 +41,7 @@ SpectronauttoMSstatsFormat = function(
                      direction = "smaller", 
                      behavior = "fill", 
                      handle_na = "keep", 
-                     fill_value = NA,
+                     fill_value = NA_real_,
                      filter = filter_with_Qvalue, 
                      drop_column = TRUE)
     qval_filter = list(score_column = "EGQvalue", 
@@ -49,7 +49,7 @@ SpectronauttoMSstatsFormat = function(
                        direction = "smaller", 
                        behavior = "fill", 
                        handle_na = "keep", 
-                       fill_value = NA, 
+                       fill_value = NA_real_, 
                        filter = filter_with_Qvalue, 
                        drop_column = TRUE)
     

--- a/R/converters_SpectronauttoMSstatsFormat.R
+++ b/R/converters_SpectronauttoMSstatsFormat.R
@@ -3,7 +3,7 @@
 #' @param input name of Spectronaut output, which is long-format. ProteinName, PeptideSequence, PrecursorCharge, FragmentIon, ProductCharge, IsotopeLabelType, Condition, BioReplicate, Run, Intensity, F.ExcludedFromQuantification are required. Rows with F.ExcludedFromQuantification=True will be removed.
 #' @param annotation name of 'annotation.txt' data which includes Condition, BioReplicate, Run. If annotation is already complete in Spectronaut, use annotation=NULL (default). It will use the annotation information from input.
 #' @param intensity 'PeakArea'(default) uses not normalized peak area. 'NormalizedPeakArea' uses peak area normalized by Spectronaut.
-#' @param filter_with_Qvalue TRUE(default) will filter out the intensities that have greater than qvalue_cutoff in EG.Qvalue column. Those intensities will be replaced with zero and will be considered as censored missing values for imputation purpose.
+#' @param filter_with_Qvalue FALSE(default) will not perform any filtering. TRUE will filter out the intensities that have greater than qvalue_cutoff in EG.Qvalue column. Those intensities will be replaced with zero and will be considered as censored missing values for imputation purpose.
 #' @param qvalue_cutoff Cutoff for EG.Qvalue. default is 0.01.
 #' @param ... additional parameters to `data.table::fread`.
 #' @inheritParams .sharedParametersAmongConverters
@@ -22,7 +22,7 @@
 #' head(spectronaut_imported)
 #' 
 SpectronauttoMSstatsFormat = function(
-        input, annotation = NULL, intensity = 'PeakArea', filter_with_Qvalue = TRUE,
+        input, annotation = NULL, intensity = 'PeakArea', filter_with_Qvalue = FALSE,
         qvalue_cutoff = 0.01, useUniquePeptide = TRUE, removeFewMeasurements=TRUE,
         removeProtein_with1Feature = FALSE, summaryforMultipleRows = max,
         use_log_file = TRUE, append = FALSE, verbose = TRUE, log_file_path = NULL,
@@ -42,14 +42,14 @@ SpectronauttoMSstatsFormat = function(
                      behavior = "fill", 
                      handle_na = "keep", 
                      fill_value = NA,
-                     filter = TRUE, 
+                     filter = filter_with_Qvalue, 
                      drop_column = TRUE)
     qval_filter = list(score_column = "EGQvalue", 
                        score_threshold = qvalue_cutoff, 
                        direction = "smaller", 
                        behavior = "fill", 
                        handle_na = "keep", 
-                       fill_value = 0, 
+                       fill_value = NA, 
                        filter = filter_with_Qvalue, 
                        drop_column = TRUE)
     

--- a/R/converters_SpectronauttoMSstatsFormat.R
+++ b/R/converters_SpectronauttoMSstatsFormat.R
@@ -65,6 +65,8 @@ SpectronauttoMSstatsFormat = function(
         score_filtering = list(pgq = pq_filter, 
                                psm_q = qval_filter),
         columns_to_fill = list("IsotopeLabelType" = "L"))
+    input[, Intensity := ifelse(Intensity == 0, NA, Intensity)]
+    
     input = MSstatsConvert::MSstatsBalancedDesign(input, feature_columns,
                                                   remove_few = removeFewMeasurements)
     

--- a/man/MSstatsConvert.Rd
+++ b/man/MSstatsConvert.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/utils_MSstatsConvert.R
 \docType{package}
 \name{MSstatsConvert}
+\alias{MSstatsConvert-package}
 \alias{MSstatsConvert}
 \title{MSstatsConvert: An R Package to Convert Data from Mass Spectrometry Signal Processing Tools to MSstats Format}
 \description{
@@ -17,3 +18,14 @@ signal processing tools to a format suitable for statistical analysis with the M
 \code{\link{MSstatsBalancedDesign}} for handling fractions and creating balanced data.
 }
 
+\author{
+\strong{Maintainer}: Mateusz Staniak \email{mtst@mstaniak.pl}
+
+Authors:
+\itemize{
+  \item Meena Choi \email{mnchoi67@gmail.com}
+  \item Ting Huang \email{thuang0703@gmail.com}
+  \item Olga Vitek \email{o.vitek@northeastern.edu}
+}
+
+}

--- a/man/SpectronauttoMSstatsFormat.Rd
+++ b/man/SpectronauttoMSstatsFormat.Rd
@@ -8,7 +8,7 @@ SpectronauttoMSstatsFormat(
   input,
   annotation = NULL,
   intensity = "PeakArea",
-  filter_with_Qvalue = TRUE,
+  filter_with_Qvalue = FALSE,
   qvalue_cutoff = 0.01,
   useUniquePeptide = TRUE,
   removeFewMeasurements = TRUE,
@@ -28,7 +28,7 @@ SpectronauttoMSstatsFormat(
 
 \item{intensity}{'PeakArea'(default) uses not normalized peak area. 'NormalizedPeakArea' uses peak area normalized by Spectronaut.}
 
-\item{filter_with_Qvalue}{TRUE(default) will filter out the intensities that have greater than qvalue_cutoff in EG.Qvalue column. Those intensities will be replaced with zero and will be considered as censored missing values for imputation purpose.}
+\item{filter_with_Qvalue}{FALSE(default) will not perform any filtering. TRUE will filter out the intensities that have greater than qvalue_cutoff in EG.Qvalue column. Those intensities will be replaced with zero and will be considered as censored missing values for imputation purpose.}
 
 \item{qvalue_cutoff}{Cutoff for EG.Qvalue. default is 0.01.}
 


### PR DESCRIPTION
# Motivation and Context

Skyline and Spectronaut converters included zeroes instead of NAs which was messing with summarization. Zeroes were being treated as real values. These zeroes have been replaced with NAs for the time being.

Going forward a deeper look into MNAR vs MCAR missingness is needed.

## Changes

- Skyline converter Os are now NAs
- Spectronaut converter Os are now NAs
- Spectronaut converter (Qvalue filtering now off by default per Meena)

## Testing

Nah

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
