### PR TITLE
ci(dry-run): Set up bioc version to use latest version of R and bioc

### DIFF
--- a/.github/workflows/dry-run-build.yml
+++ b/.github/workflows/dry-run-build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup R and Bioconductor
         uses: grimbough/bioc-actions/setup-bioc@v1
         with:
-          bioc-version: release
+          bioc-version: devel
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
       - name: Build, Install, Check


### PR DESCRIPTION
# Motivation and Context

See this [PR](https://github.com/Vitek-Lab/MSstats/pull/124) for context

## Changes

- Update bioc version used in dry run builds. The mapping can be found [here](https://github.com/grimbough/bioc-actions/blob/v1-branch/setup-bioc/bioc-version-map.csv)

## Testing

- Dry run build succeeds

## Checklist Before Requesting a Review
- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
