### PR TITLE
fix(PD-converter): Enable spectrumFile to be used for run ID in PD converter

### DIFF
--- a/R/clean_ProteomeDiscoverer.R
+++ b/R/clean_ProteomeDiscoverer.R
@@ -28,7 +28,8 @@
 #' @return data.table
 #' @keywords internal
 .cleanRawPDMSstats = function(msstats_object, quantification_column, 
-                              protein_id_column, sequence_column, remove_shared
+                              protein_id_column, sequence_column, remove_shared,
+                              run_column = "SpectrumFile"
 ) {
   XProteins = NULL
   
@@ -36,7 +37,6 @@
   protein_id_column = .standardizeColnames(protein_id_column)
   sequence_column = .standardizeColnames(sequence_column)
   quantification_column = .standardizeColnames(quantification_column)
-  run_column = ifelse(any(grepl("FileID", colnames(pd_input))), "FileID", "SpectrumFile")
   
   if (remove_shared & is.element("XProteins", colnames(pd_input))) {
     pd_input = pd_input[XProteins == "1", ]


### PR DESCRIPTION
# Motivation and Context

Similar to this [commit](https://github.com/Vitek-Lab/MSstatsConvert/commit/abda89b256fcc8c94d72376ba671fb552ded3215#diff-80d66ecca7c01ccffdd293533494576119e68ebeb729ab3e156549565c2c448dL76), but I'm pretty sure we should use SpectrumFile for the regular MSstats converter.  Unit tests for MSstatsPTM seem to assume we use SpectrumFile.  

## Changes

- Updated clean function to use SpectrumFile for the regular MSstats converter for PD.

## Testing

- Unit tests pass in MSstatsConvert, MSstats, MSstatsPTM.  Previously, tests in MSstatsPTM were failing.
- ~~Note: I'm a little concerned about backwards compatibility here.  People previously using FileID will end up having workflows breaking.~~
- Future: I'll add a run column for the PD MSstats and TMT converters to enable run ID.

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
