### PR TITLE
add initial validation function for spectronaut columns

### DIFF
--- a/R/clean_Spectronaut.R
+++ b/R/clean_Spectronaut.R
@@ -7,6 +7,7 @@
   FFrgLossType = FExcludedFromQuantification = NULL
   
   spec_input = getInputFile(msstats_object, "input")
+  .validateSpectronautInput(spec_input)
   spec_input = spec_input[FFrgLossType == "noloss", ]
   
   if (is.character(spec_input$FExcludedFromQuantification)) {
@@ -31,4 +32,20 @@
     skip_absent = TRUE)
   .logSuccess("Spectronaut", "clean")
   spec_input
+}
+
+#' Helper method to validate input has necessary columns
+#' @param spec_input dataframe input
+#' @noRd
+.validateSpectronautInput = function(spec_input) {
+    required_columns = c(
+        "FFrgLossType", "FExcludedFromQuantification", "PGProteinGroups",
+        "FGCharge")
+    missing_columns = setdiff(required_columns, colnames(spec_input))
+    if (length(missing_columns) > 0) {
+        msg = paste("The following columns are missing from the input data:", 
+                    paste(missing_columns, sep = ", ", collapse = ", "))
+        getOption("MSstatsLog")("ERROR", msg)
+        stop(msg)
+    }
 }

--- a/inst/tinytest/test_converters_SpectronauttoMSstatsFormat.R
+++ b/inst/tinytest/test_converters_SpectronauttoMSstatsFormat.R
@@ -16,3 +16,42 @@ expect_true("IsotopeLabelType" %in% colnames(output))
 expect_true("Condition" %in% colnames(output))
 expect_true("BioReplicate" %in% colnames(output))
 expect_true("Fraction" %in% colnames(output))
+
+
+# Test SpectronauttoMSstatsFormat Missing Columns ---------------------------
+spectronaut_raw = system.file("tinytest/raw_data/Spectronaut/spectronaut_input.csv",
+                              package = "MSstatsConvert")
+spectronaut_raw = data.table::fread(spectronaut_raw)
+spectronaut_raw$F.ExcludedFromQuantification = NULL
+expect_error(
+    SpectronauttoMSstatsFormat(spectronaut_raw, use_log_file = FALSE),
+    "The following columns are missing from the input data: FExcludedFromQuantification"
+)
+
+spectronaut_raw = system.file("tinytest/raw_data/Spectronaut/spectronaut_input.csv",
+                              package = "MSstatsConvert")
+spectronaut_raw = data.table::fread(spectronaut_raw)
+spectronaut_raw$F.FrgLossType = NULL
+expect_error(
+    SpectronauttoMSstatsFormat(spectronaut_raw, use_log_file = FALSE),
+    "The following columns are missing from the input data: FFrgLossType"
+)
+
+spectronaut_raw = system.file("tinytest/raw_data/Spectronaut/spectronaut_input.csv",
+                              package = "MSstatsConvert")
+spectronaut_raw = data.table::fread(spectronaut_raw)
+spectronaut_raw$PG.ProteinGroups = NULL
+expect_error(
+    SpectronauttoMSstatsFormat(spectronaut_raw, use_log_file = FALSE),
+    "The following columns are missing from the input data: PGProteinGroups"
+)
+
+spectronaut_raw = system.file("tinytest/raw_data/Spectronaut/spectronaut_input.csv",
+                              package = "MSstatsConvert")
+spectronaut_raw = data.table::fread(spectronaut_raw)
+spectronaut_raw$FG.Charge = NULL
+expect_error(
+    SpectronauttoMSstatsFormat(spectronaut_raw, use_log_file = FALSE),
+    "The following columns are missing from the input data: FGCharge"
+)
+


### PR DESCRIPTION
# Motivation and Context

See https://groups.google.com/g/msstats/c/E0LURUXN_dk

## Changes

Make a more clear error message when certain columns are missing.  Due to missing columns, converter filters table down to be empty, which leaves an ambiguous error message later on.  Rather would fail fast early.

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
