### PR TITLE
fix(pd-converter): Remove QuanInfo column after cleaning up PD data

### DIFF
--- a/R/clean_ProteomeDiscoverer.R
+++ b/R/clean_ProteomeDiscoverer.R
@@ -131,7 +131,7 @@
       pd_input = pd_input[toupper(QuanInfo) == 'UNIQUE', ]
     }
   }
-  pd_input = pd_input[, !(colnames(pd_input) %in% "QuanInfo")]
+  pd_input = pd_input[, !(colnames(pd_input) %in% "QuanInfo"), with = FALSE]
   pd_input
 }
 

--- a/R/clean_ProteomeDiscoverer.R
+++ b/R/clean_ProteomeDiscoverer.R
@@ -131,6 +131,7 @@
       pd_input = pd_input[toupper(QuanInfo) == 'UNIQUE', ]
     }
   }
+  pd_input = pd_input[, setdiff(colnames(pd_input), c("QuanInfo")), with = FALSE]
   pd_input
 }
 

--- a/R/clean_ProteomeDiscoverer.R
+++ b/R/clean_ProteomeDiscoverer.R
@@ -131,7 +131,7 @@
       pd_input = pd_input[toupper(QuanInfo) == 'UNIQUE', ]
     }
   }
-  pd_input = pd_input[, setdiff(colnames(pd_input), c("QuanInfo")), with = FALSE]
+  pd_input = pd_input[, !(colnames(pd_input) %in% "QuanInfo")]
   pd_input
 }
 

--- a/inst/tinytest/test_cleanRaw.R
+++ b/inst/tinytest/test_cleanRaw.R
@@ -146,7 +146,7 @@ expect_error(MSstatsConvert::MSstatsClean(pdtmt_import,
                                           remove_shared = TRUE,
                                           intensity_columns_regexp = "Nothing"))
 expect_equal(
-    ncol(pdtmt_cleaned), 11
+    ncol(pdtmt_cleaned), 10
 )
 expect_true(nrow(pdtmt_cleaned) > 0)
 # Progenesis

--- a/inst/tinytest/test_clean_ProteomeDiscoverer.R
+++ b/inst/tinytest/test_clean_ProteomeDiscoverer.R
@@ -1,6 +1,6 @@
 .testHappyPath = function(input) {
     output = MSstatsConvert:::.cleanRawPDTMT(input)
-    expect_equal(ncol(output), 11)
+    expect_equal(ncol(output), 10)
     expect_true(nrow(output) > 0)
     expected_column_names = c(
         "ProteinName",
@@ -9,7 +9,6 @@
         "PrecursorCharge",
         "IonsScore",
         "Run",
-        "QuanInfo",
         "IsolationInterference",
         "PSM",
         "Channel",


### PR DESCRIPTION
# Motivation and Context

https://groups.google.com/g/msstats/c/8OrKxfxMxOo - The PD converter does not remove the QuanInfo column from the input data frame.  `QuanInfo` is a PD specific column and is not referenced anywhere else in the code.  However, this column causes problems with summarizing multiple PSMs:

Workflow:
- It is a common edge case when summarizing with `max` where if we have duplicate PSMs with equal max intensities [here](https://github.com/Vitek-Lab/MSstatsConvert/blob/02e15072d1ed4e934616e51d2c5865915570eed2/R/utils_clean_features.R#L280-L287), we cannot determine which PSM to use to summarize a feature.  
- Under this circumstance, we summarize the PSMs into a feature via taking the mean of the PSMs [here](https://github.com/Vitek-Lab/MSstatsConvert/blob/02e15072d1ed4e934616e51d2c5865915570eed2/R/utils_clean_features.R#L184)
- However, if `QuanInfo` is included, the code may mistaken two duplicate PSMs as being associated with different features [here](https://github.com/Vitek-Lab/MSstatsConvert/blob/02e15072d1ed4e934616e51d2c5865915570eed2/R/utils_clean_features.R#L183-L190), leading to duplicate PSMs remaining in the input data.
- `proteinSummarization` / `dataProcess` crashes when there's multiple PSMs of the same feature.

I've determined the best solution is to remove `QuanInfo` from the input data frame during conversion.

## Changes

- Remove `QuanInfo` column from the pd input table after cleanup since it is not needed anymore.

## Testing

Fixed existing unit tests

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
