### PR TITLE
fix(diann): Convert zeros to NAs

### DIFF
--- a/R/converters_DIANNtoMSstatsFormat.R
+++ b/R/converters_DIANNtoMSstatsFormat.R
@@ -133,6 +133,7 @@ DIANNtoMSstatsFormat = function(input, annotation = NULL,
             summarize_multiple_psms = max),
         columns_to_fill = list(Fraction = 1,
                                IsotopeLabelType = "Light"))
+    input[, Intensity := ifelse(Intensity == 0, NA, Intensity)]
     
     input = MSstatsConvert::MSstatsBalancedDesign(input, feature_columns, 
                                                   fill_incomplete = FALSE,


### PR DESCRIPTION
# Motivation and Context

For DIANN 2.0, 0s are being reported for missing values in some scenarios. 

## Changes

Replace zeros with NAs in DIANN converter for now.

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of zero intensity values in DIANN data conversion by treating them as missing values during preprocessing, ensuring more accurate downstream analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->