### PR TITLE
Fix turnover

### DIFF
--- a/R/converters_SpectronauttoMSstatsFormat.R
+++ b/R/converters_SpectronauttoMSstatsFormat.R
@@ -139,14 +139,15 @@ SpectronauttoMSstatsFormat = function(
     
     feature_columns = c("PeptideSequence", "PrecursorCharge",
                         "FragmentIon", "ProductCharge")
-    
-    fill_isotope_label_type = if (is.null(heavyLabels)) 
-        list("IsotopeLabelType" = "L") else list()
+    preprocess_feature_columns = if ("IsotopeLabelType" %in% colnames(input))
+        c(feature_columns, "IsotopeLabelType") else feature_columns
+    fill_isotope_label_type = if ("IsotopeLabelType" %in% colnames(input)) 
+        list() else list("IsotopeLabelType" = "L") 
     
     input = MSstatsConvert::MSstatsPreprocess(
         input,
         annotation,
-        feature_columns,
+        preprocess_feature_columns,
         remove_shared_peptides = useUniquePeptide,
         remove_single_feature_proteins = removeProtein_with1Feature,
         feature_cleaning = list(remove_features_with_few_measurements = removeFewMeasurements,

--- a/inst/tinytest/test_converters_SpectronauttoMSstatsFormat.R
+++ b/inst/tinytest/test_converters_SpectronauttoMSstatsFormat.R
@@ -427,3 +427,17 @@ output_leu = SpectronauttoMSstatsFormat(
     use_log_file = FALSE
 )
 expect_false("H" %in% unique(output_leu$IsotopeLabelType))
+
+# Verify intensity values for ANGYTTEYSASVK are preserved from FG.MS1Quantity
+output_heavy = data.table::as.data.table(output_heavy)
+angyt_input_intensities = sort(
+    boxcar_raw[PEP.StrippedSequence == "ANGYTTEYSASVK", FG.MS1Quantity])
+angyt_output_intensities = sort(
+    output_heavy[grepl("ANGYTTEYSASVK", PeptideSequence, fixed = TRUE), Intensity])
+expect_equivalent(angyt_input_intensities, angyt_output_intensities)
+
+# Verify row count for ANGYTTEYSASVK is 2 * number of bioreplicates
+# (one row per bioreplicate for heavy label, one for light label)
+n_bioreplicates = length(unique(boxcar_raw$R.Replicate))
+angyt_rows = subset(output_heavy, grepl("ANGYTTEYSASVK", PeptideSequence, fixed = TRUE))
+expect_equal(nrow(angyt_rows), 2L * n_bioreplicates)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

This PR fixes a critical issue in the Spectronaut converter's handling of isotope label types in protein turnover experiments. The problem occurs when the `IsotopeLabelType` column is already present in the cleaned input data (which happens after the cleaning step processes heavy isotope labels). Previously, the code was unconditionally filling missing `IsotopeLabelType` values with "L" based on the `heavyLabels` parameter, but this logic failed to account for scenarios where `IsotopeLabelType` was already populated by the cleaning function. This caused incorrect handling of feature balancing in the preprocessing step and improper row counts when light and heavy isotope variants needed to be distinguished.

The fix ensures that when `IsotopeLabelType` is already present, it is treated as a feature column for preprocessing and not overwritten with default values.

## Changes

### R/converters_SpectronauttoMSstatsFormat.R

- **Added conditional logic for feature column handling**: Introduced `preprocess_feature_columns` variable that checks if `IsotopeLabelType` already exists in the input. If present, it extends `feature_columns` to include `IsotopeLabelType`; otherwise, it uses the original `feature_columns` unchanged.

- **Updated isotope label filling logic**: Modified `fill_isotope_label_type` to be conditionally empty when `IsotopeLabelType` is already present in the input (no default fill), but retains the original fill behavior (setting to "L") when the column is missing.

- **Changed MSstatsPreprocess call**: Updated the call from passing `feature_columns` to passing `preprocess_feature_columns`, ensuring the preprocessing step correctly handles isotope labels as a feature dimension when appropriate.

## Unit Tests

### inst/tinytest/test_converters_SpectronauttoMSstatsFormat.R

Added two assertions to the "Heavy Label Testing" section:

1. **Intensity preservation test**: Extracts `FG.MS1Quantity` values from the input (`boxcar_raw`) for the peptide "ANGYTTEYSASVK", retrieves corresponding `Intensity` values from the output (`output_heavy`) matching the same peptide sequence, and verifies they are equivalent using `expect_equivalent`.

2. **Row count validation test**: Computes the number of unique bioreplicates from the input, filters the output for rows matching "ANGYTTEYSASVK", and verifies the resulting row count equals `2L * n_bioreplicates` (accounting for one row each for heavy and light isotope labels per bioreplicate) using `expect_equal`.

Both tests wrap `output_heavy` as a data.table to enable row/column subsetting operations.

## Coding Guidelines

No violations of the project's coding guidelines are evident. The changes follow the existing code style and patterns:
- Uses conditional statements appropriately for logical branching
- Variable naming follows the underscore-separated lowercase convention used elsewhere in the codebase
- The modifications maintain consistency with existing feature column handling patterns
- Test assertions follow the project's tinytest conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->