### PR TITLE
Fix fraction efficient

### DIFF
--- a/R/utils_fractions.R
+++ b/R/utils_fractions.R
@@ -264,70 +264,52 @@
 #' @return data.table
 #' @keywords internal
 .removeOverlappingFeatures = function(input) {
-    fraction_keep = Fraction = NULL
+    Fraction = NULL
     
     if (data.table::uniqueN(input$Fraction) > 1) {
-        # Step 1: count unique Runs per feature+Fraction
         measurement_count = input[
             !is.na(Intensity) & Intensity > 0,
             .(n_obs = uniqueN(Run)),
             by = .(feature, Fraction)
         ]
-        
-        # Step 2: keep only the Fraction(s) with max n_obs per feature
         measurement_count[, is_max := n_obs == max(n_obs), by = "feature"]
         max_fractions = measurement_count[(is_max)]
         
-        # Step 3: if tie, resolve by mean intensity
-        tie_features = max_fractions[, .(n_ties = .N), by = "feature"][n_ties > 1, feature]
-        
-        if (length(tie_features) > 0) {
-            avg_abundance = input[
-                feature %in% tie_features & !is.na(Intensity) & Intensity > 0,
-                .(mean_abundance = mean(Intensity)),
-                by = .(feature, Fraction)
-            ]
-            best_tied = avg_abundance[, .SD[which.max(mean_abundance)], by = "feature"]
-            best_simple = max_fractions[
-                !feature %in% tie_features,
-                .(Fraction = Fraction[1]),
-                by = "feature"
-            ]
-            fraction_map = rbind(best_simple[, .(feature, Fraction)],
-                                 best_tied[, .(feature, Fraction)])
-        } else {
-            fraction_map = max_fractions[, .(Fraction = Fraction[1]), by = "feature"]
-        }
-        
-        # Step 4: filter input to only rows matching the selected fraction per feature
+        fraction_map = .resolveFractionTies(input, max_fractions)
         input = input[fraction_map, on = .(feature, Fraction), nomatch = 0]
     }
     input
 }
 
 
-#' Get a name of fraction with the largest number of measurements or the largest
-#' average intensity
+#' Resolve ties when multiple fractions share the maximum number of measurements
+#' for a given feature. In the case of a tie, the fraction with the highest
+#' mean intensity is selected.
 #' @param input output of `MSstatsPreprocess`
-#' @return character - label of the fraction that has most measurements or
-#' highest mean intensity for a given feature
+#' @param max_fractions data.table of fractions that share the maximum number
+#' of unique runs per feature, as produced by `.removeOverlappingFeatures`
+#' @return data.table with columns `feature` and `Fraction`, containing one
+#' selected fraction per feature
 #' @keywords internal
-.getCorrectFraction = function(input) {
-    Intensity = Run = Fraction = NULL
+.resolveFractionTies = function(input, max_fractions) {
+    tie_features = max_fractions[, .(n_ties = .N), by = "feature"][n_ties > 1, feature]
     
-    measurement_count = input[!is.na(Intensity) & Intensity > 0, 
-                              list(n_obs = data.table::uniqueN(Run)),
-                              by = "Fraction"]
-    which_max_measurements = which(measurement_count$n_obs == max(measurement_count$n_obs))
-    if (length(which_max_measurements) == 1L) {
-        return(unique(measurement_count$Fraction[which_max_measurements]))
+    if (length(tie_features) > 0) {
+        avg_abundance = input[
+            feature %in% tie_features & !is.na(Intensity) & Intensity > 0,
+            .(mean_abundance = mean(Intensity)),
+            by = .(feature, Fraction)
+        ]
+        best_tied = avg_abundance[, .SD[which.max(mean_abundance)], by = "feature"]
+        best_simple = max_fractions[
+            !feature %in% tie_features,
+            .(Fraction = Fraction[1]),
+            by = "feature"
+        ]
+        rbind(best_simple[, .(feature, Fraction)],
+              best_tied[, .(feature, Fraction)])
     } else {
-        input = input[Fraction %in% measurement_count$Fraction[which_max_measurements]]
-        average_abundance = input[!is.na(Intensity) & Intensity > 0, 
-                                  list(mean_abundance = mean(Intensity)),
-                                  by = "Fraction"]
-        which_max_abundance = which.max(average_abundance$mean_abundance)
-        unique(average_abundance$Fraction[which_max_abundance])
+        max_fractions[, .(Fraction = Fraction[1]), by = "feature"]
     }
 }
 

--- a/R/utils_fractions.R
+++ b/R/utils_fractions.R
@@ -295,11 +295,12 @@
     tie_features = max_fractions[, .(n_ties = .N), by = "feature"][n_ties > 1, feature]
     
     if (length(tie_features) > 0) {
+        tied_fractions = max_fractions[feature %in% tie_features, .(feature, Fraction)]
         avg_abundance = input[
-            feature %in% tie_features & !is.na(Intensity) & Intensity > 0,
-            .(mean_abundance = mean(Intensity)),
-            by = .(feature, Fraction)
-        ]
+            tied_fractions, on = .(feature, Fraction), nomatch = 0
+        ][!is.na(Intensity) & Intensity > 0,
+          .(mean_abundance = mean(Intensity)),
+          by = .(feature, Fraction)]
         best_tied = avg_abundance[, .SD[which.max(mean_abundance)], by = "feature"]
         best_simple = max_fractions[
             !feature %in% tie_features,

--- a/R/utils_fractions.R
+++ b/R/utils_fractions.R
@@ -287,21 +287,20 @@
                 .(mean_abundance = mean(Intensity)),
                 by = .(feature, Fraction)
             ]
-            # Pick the Fraction with highest mean per tied feature
             best_tied = avg_abundance[, .SD[which.max(mean_abundance)], by = "feature"]
-            
-            # For non-tied features, just take the max fraction
-            best_simple = max_fractions[!feature %in% tie_features, 
-                                        .(feature, Fraction = Fraction[1]), 
-                                        by = "feature"]
-            fraction_map = rbind(best_simple[, .(feature, Fraction)], 
+            best_simple = max_fractions[
+                !feature %in% tie_features,
+                .(Fraction = Fraction[1]),
+                by = "feature"
+            ]
+            fraction_map = rbind(best_simple[, .(feature, Fraction)],
                                  best_tied[, .(feature, Fraction)])
         } else {
-            fraction_map = max_fractions[, .(feature, Fraction = Fraction[1]), by = "feature"]
+            fraction_map = max_fractions[, .(Fraction = Fraction[1]), by = "feature"]
         }
         
-        # Step 4: single join back to original table
-        input[fraction_map, fraction_keep := i.Fraction, on = "feature"]
+        # Step 4: filter input to only rows matching the selected fraction per feature
+        input = input[fraction_map, on = .(feature, Fraction), nomatch = 0]
     }
     input
 }

--- a/R/utils_fractions.R
+++ b/R/utils_fractions.R
@@ -267,11 +267,41 @@
     fraction_keep = Fraction = NULL
     
     if (data.table::uniqueN(input$Fraction) > 1) {
-        input[, fraction_keep := .getCorrectFraction(.SD), 
-              by = "feature", 
-              .SDcols = c("feature", "Fraction", "Run", "Intensity")]
-        input = input[Fraction == fraction_keep]
-        input = input[, !(colnames(input) == "fraction_keep"), with = FALSE]
+        # Step 1: count unique Runs per feature+Fraction
+        measurement_count = input[
+            !is.na(Intensity) & Intensity > 0,
+            .(n_obs = uniqueN(Run)),
+            by = .(feature, Fraction)
+        ]
+        
+        # Step 2: keep only the Fraction(s) with max n_obs per feature
+        measurement_count[, is_max := n_obs == max(n_obs), by = "feature"]
+        max_fractions = measurement_count[(is_max)]
+        
+        # Step 3: if tie, resolve by mean intensity
+        tie_features = max_fractions[, .(n_ties = .N), by = "feature"][n_ties > 1, feature]
+        
+        if (length(tie_features) > 0) {
+            avg_abundance = input[
+                feature %in% tie_features & !is.na(Intensity) & Intensity > 0,
+                .(mean_abundance = mean(Intensity)),
+                by = .(feature, Fraction)
+            ]
+            # Pick the Fraction with highest mean per tied feature
+            best_tied = avg_abundance[, .SD[which.max(mean_abundance)], by = "feature"]
+            
+            # For non-tied features, just take the max fraction
+            best_simple = max_fractions[!feature %in% tie_features, 
+                                        .(feature, Fraction = Fraction[1]), 
+                                        by = "feature"]
+            fraction_map = rbind(best_simple[, .(feature, Fraction)], 
+                                 best_tied[, .(feature, Fraction)])
+        } else {
+            fraction_map = max_fractions[, .(feature, Fraction = Fraction[1]), by = "feature"]
+        }
+        
+        # Step 4: single join back to original table
+        input[fraction_map, fraction_keep := i.Fraction, on = "feature"]
     }
     input
 }

--- a/inst/tinytest/test_fractions.R
+++ b/inst/tinytest/test_fractions.R
@@ -82,6 +82,19 @@ expect_identical(
     MSstatsConvert:::.removeOverlappingFeatures(data.table::copy(fractionated)),
     fractionated[Fraction == 2]
 )
+### Non-tied fraction with high mean intensity should not be selected over tied fractions
+fractionated_third = data.table::data.table(
+    feature = rep("A", 9),
+    Fraction = c(rep(1, 3), rep(2, 3), rep(3, 3)),
+    Run = 1:9,
+    Intensity = c(1, 1, 1,    # Fraction 1: 3 obs, mean = 1 (ties for max n_obs)
+                  2, 2, 2,    # Fraction 2: 3 obs, mean = 2 (ties for max n_obs)
+                  10, NA, NA) # Fraction 3: 1 obs, mean = 10 (loses on n_obs but mean would win w/o fix)
+)
+expect_equal(
+    unique(MSstatsConvert:::.removeOverlappingFeatures(fractionated_third)$Fraction),
+    2
+)
 fractionated_tmt = fractionated = data.table::data.table(
     feature = rep(c("A", "B"), each = 6),
     Fraction = rep(rep(c(1, 2), each = 3), times = 2),

--- a/inst/tinytest/test_fractions.R
+++ b/inst/tinytest/test_fractions.R
@@ -67,12 +67,16 @@ fractionated = data.table::data.table(
     Run = 1:12,
     Intensity = c(NA, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2)
 )
-picked_A = MSstatsConvert:::.getCorrectFraction(fractionated[feature == "A"])
-picked_B = MSstatsConvert:::.getCorrectFraction(fractionated[feature == "B"])
 ### More observations win
-expect_equal(picked_A, 2)
-### Higher average intensity wins
-expect_equal(picked_B, 2)
+expect_equal(
+    unique(MSstatsConvert:::.removeOverlappingFeatures(fractionated[feature == "A"])$Fraction),
+    2
+)
+### Higher average intensity wins on tie
+expect_equal(
+    unique(MSstatsConvert:::.removeOverlappingFeatures(fractionated[feature == "B"])$Fraction),
+    2
+)
 ### For full data
 expect_identical(
     MSstatsConvert:::.removeOverlappingFeatures(data.table::copy(fractionated)),


### PR DESCRIPTION
# Motivation and Context

Please include relevant motivation and context of the problem along with a short summary of the solution.

## Changes

Please provide a detailed bullet point list of your changes.

- 

## Testing

Please describe any unit tests you added or modified to verify your changes.

## Checklist Before Requesting a Review
- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

The MSstatsConvert package processes mass spectrometry-based proteomics data and handles cases where peptide features are measured across multiple fractions. When a feature appears in multiple fractions within a sample, the code must select which fraction's measurement to retain. The previous implementation used a less efficient approach that lacked clear separation of concerns between fraction selection and tie-resolution logic. This PR improves efficiency and code clarity by refactoring the fraction selection mechanism.

## Solution

The refactoring centralizes tie-resolution logic into a dedicated function and makes the fraction selection process more efficient. Instead of applying tie-break logic during iteration, the new approach:
1. Pre-computes fractions with maximum observation counts per feature (based on unique Run counts where Intensity > 0)
2. Identifies which features have tied fractions (multiple fractions sharing the max count)
3. For tied features, selects the fraction with the highest mean Intensity
4. For non-tied features, selects the first available fraction with max observations
5. Uses data.table joins to filter the input to only retain the selected fractions

## Detailed Changes

### `R/utils_fractions.R`
- **Refactored `.removeOverlappingFeatures()`**: 
  - Now computes candidate fractions based on `uniqueN(Run)` among rows with `!is.na(Intensity) & Intensity > 0` per feature-Fraction combination
  - Creates a `fraction_map` via `.resolveFractionTies()` helper function
  - Filters input using a single data.table join: `input[fraction_map, on=.(feature, Fraction), nomatch=0]`
  - Removed intermediate `fraction_keep` column logic that previously relied on row-by-row evaluation

- **Replaced `.getCorrectFraction()` with `.resolveFractionTies(input, max_fractions)`**:
  - New function signature accepts both input data and pre-computed max_fractions
  - Identifies `tie_features` where multiple fractions share maximum `n_obs` per feature
  - For tied features: selects fraction with highest mean Intensity using `which.max(mean_abundance)` grouped by feature and Fraction
  - For non-tied features: selects first fraction in max_fractions per feature
  - Returns results via `rbind()` combining both groups
  - Added documentation explaining the tie-resolution logic

- **Lines changed**: +35/-24

### `inst/tinytest/test_fractions.R`
- **Updated test logic**: Instead of calling `.getCorrectFraction()` directly on individual features, tests now:
  - Call `.removeOverlappingFeatures()` on per-feature subsets
  - Extract the resulting `Fraction` values
  - Assert the unique fraction equals the expected value (2 for both feature "A" and feature "B" tie case)
  
- **Test coverage maintained**: The test continues to validate `.removeOverlappingFeatures()` on the full dataset using `expect_identical()`

- **Lines changed**: +9/-5

## Unit Tests

The test suite verifies the refactored logic through:
1. **Observation count selection** (lines 70-74): Validates that the fraction with more observations (Run count) wins when comparing fractions for the same feature
2. **Mean intensity tie-breaking** (lines 75-79): Validates that when two fractions have equal observation counts, the fraction with higher average Intensity is selected
3. **Full dataset processing** (lines 80-84): Confirms that the tie-resolution logic correctly processes the complete fractionated dataset and retains only rows from the selected fraction (Fraction == 2)

All tests continue to pass with the new implementation, confirming backward compatibility of the selection behavior.

## Coding Guidelines

No coding guideline violations identified. The code:
- Follows R/data.table idioms and conventions used throughout the package
- Includes comprehensive roxygen documentation for the new `.resolveFractionTies()` function
- Maintains clear function naming conventions with dot-prefix for internal functions
- Uses appropriate data.table syntax (`:=`, `.N`, `.SD`, `by=`, `on=`)
- Properly handles NULL values and NA/zero filtering conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->