### PR TITLE
make run order determine levels of run

### DIFF
--- a/R/MSstatsConvert_core_functions.R
+++ b/R/MSstatsConvert_core_functions.R
@@ -571,7 +571,10 @@ MSstatsAnomalyScores = function(input, quality_metrics, temporal_direction,
     
     subset_cols = subset_cols[subset_cols %in% names(input)]
     input = input[, ..subset_cols]
-    
+
+    ordered_runs = .standardizeColnames(run_order$Run[order(run_order$Order)])
+    input$Run = factor(input$Run, levels = ordered_runs)
+
     return(input)
 
 }


### PR DESCRIPTION
# Motivation and Context

We want to somehow embed the run order into the MSstats input without having to create a new run order column.

## Changes

- Make the Run column a factor with levels in the order of the run order.

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
