### PR TITLE
standardize column names for run for MSstatsAnomalyScores

### DIFF
--- a/R/utils_anomaly_score.R
+++ b/R/utils_anomaly_score.R
@@ -6,6 +6,7 @@
                                            n_feat=100,
                                            missing_run_count=.5){
     input = as.data.table(input)
+    input$Run = .standardizeColnames(input$Run)
     
     input$Fragment = paste(input$PeptideSequence,
                            input$PrecursorCharge, 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Motivation and context
- Inconsistent Run column naming from different backends (e.g., Spectronaut) could break run-level filtering, fragment construction, and the merge with run order in MSstatsAnomalyScores.
- Solution: Standardize Run column values early in anomaly input preparation so downstream steps rely on a consistent key.

Detailed changes
- R/utils_anomaly_score.R
    - Standardize input$Run via .standardizeColnames(input$Run) before:
      - Constructing Fragment identifiers.
      - Computing runs = length(unique(input$Run)) for missingness-based fragment filtering.
    - Ensure run_order$Run is standardized via .standardizeColnames(run_order$Run) prior to merging.
    - Merge performed by "Run" relies on standardized keys to prevent dropped rows or misaligned orders.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vitek-Lab/MSstatsConvert/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->