### PR TITLE
Fix docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,6 @@ License: Artistic-2.0
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 biocViews: MassSpectrometry, Proteomics, Software, DataImport, QualityControl
 Depends:
     R (>= 4.0)
@@ -82,3 +81,4 @@ Collate:
     'utils_logging.R'
     'utils_shared_peptides.R'
 VignetteBuilder: knitr
+Config/roxygen2/version: 8.0.0

--- a/R/utils_documentation.R
+++ b/R/utils_documentation.R
@@ -5,7 +5,14 @@
 #' @param removeFewMeasurements TRUE (default) will remove the features that have 1 or 2 measurements across runs.
 #' @param useUniquePeptide TRUE (default) removes peptides that are assigned for more than one proteins. 
 #' We assume to use unique peptide for each protein.
-#' @param summaryforMultipleRows max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.
+#' @param summaryforMultipleRows max or sum - when multiple PSMs identify
+#' the same feature within a single MS run (duplicate PSMs), use the
+#' highest (max) or sum of the duplicate intensities. Default is max for
+#' label-free converters and sum for TMT converters. This parameter does
+#' not control collapsing across fractions of the same biological mixture;
+#' fraction handling is performed separately by `MSstatsBalancedDesign()`
+#' (see the "Fractions and balanced design" section of the data format
+#' vignette).
 #' @param removeProtein_with1Feature TRUE will remove the proteins which have only 1 feature, which is the combination of peptide, precursor charge, fragment and charge. FALSE is default.
 #' @param removeProtein_with1Peptide TRUE will remove the proteins which have only 1 peptide and charge. FALSE is default.
 #' @param removeOxidationMpeptides TRUE will remove the peptides including 'oxidation (M)' in modification. FALSE is default.

--- a/R/utils_documentation.R
+++ b/R/utils_documentation.R
@@ -8,11 +8,8 @@
 #' @param summaryforMultipleRows max or sum - when multiple PSMs identify
 #' the same feature within a single MS run (duplicate PSMs), use the
 #' highest (max) or sum of the duplicate intensities. Default is max for
-#' label-free converters and sum for TMT converters. This parameter does
-#' not control collapsing across fractions of the same biological mixture;
-#' fraction handling is performed separately by `MSstatsBalancedDesign()`
-#' (see the "Fractions and balanced design" section of the data format
-#' vignette).
+#' label-free converters and sum for TMT converters. Note that this parameter 
+#' does NOT control collapsing across fractions of the same biological mixture.
 #' @param removeProtein_with1Feature TRUE will remove the proteins which have only 1 feature, which is the combination of peptide, precursor charge, fragment and charge. FALSE is default.
 #' @param removeProtein_with1Peptide TRUE will remove the proteins which have only 1 peptide and charge. FALSE is default.
 #' @param removeOxidationMpeptides TRUE will remove the peptides including 'oxidation (M)' in modification. FALSE is default.

--- a/man/DIAUmpiretoMSstatsFormat.Rd
+++ b/man/DIAUmpiretoMSstatsFormat.Rd
@@ -41,11 +41,8 @@ DIAUmpiretoMSstatsFormat(
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/DIAUmpiretoMSstatsFormat.Rd
+++ b/man/DIAUmpiretoMSstatsFormat.Rd
@@ -38,7 +38,14 @@ DIAUmpiretoMSstatsFormat(
 
 \item{removeProtein_with1Feature}{TRUE will remove the proteins which have only 1 feature, which is the combination of peptide, precursor charge, fragment and charge. FALSE is default.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/FragPipetoMSstatsFormat.Rd
+++ b/man/FragPipetoMSstatsFormat.Rd
@@ -30,11 +30,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/FragPipetoMSstatsFormat.Rd
+++ b/man/FragPipetoMSstatsFormat.Rd
@@ -27,7 +27,14 @@ We assume to use unique peptide for each protein.}
 
 \item{removeProtein_with1Feature}{TRUE will remove the proteins which have only 1 feature, which is the combination of peptide, precursor charge, fragment and charge. FALSE is default.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/MSstatsConvert.Rd
+++ b/man/MSstatsConvert.Rd
@@ -23,6 +23,7 @@ signal processing tools to a format suitable for statistical analysis with the M
 
 Authors:
 \itemize{
+  \item Anthony Wu \email{wu.anthon@northeastern.edu}
   \item Mateusz Staniak \email{mtst@mstaniak.pl}
   \item Devon Kohler \email{kohler.d@northeastern.edu}
   \item Meena Choi \email{mnchoi67@gmail.com}

--- a/man/MaxQtoMSstatsFormat.Rd
+++ b/man/MaxQtoMSstatsFormat.Rd
@@ -37,11 +37,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{removeFewMeasurements}{TRUE (default) will remove the features that have 1 or 2 measurements across runs.}
 

--- a/man/MaxQtoMSstatsFormat.Rd
+++ b/man/MaxQtoMSstatsFormat.Rd
@@ -34,7 +34,14 @@ MaxQtoMSstatsFormat(
 \item{useUniquePeptide}{TRUE (default) removes peptides that are assigned for more than one proteins.
 We assume to use unique peptide for each protein.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{removeFewMeasurements}{TRUE (default) will remove the features that have 1 or 2 measurements across runs.}
 

--- a/man/MaxQtoMSstatsTMTFormat.Rd
+++ b/man/MaxQtoMSstatsTMTFormat.Rd
@@ -39,7 +39,14 @@ We assume to use unique peptide for each protein.}
 
 \item{rmProtein_with1Feature}{TRUE will remove the proteins which have only 1 peptide and charge. Default is FALSE.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/MaxQtoMSstatsTMTFormat.Rd
+++ b/man/MaxQtoMSstatsTMTFormat.Rd
@@ -42,11 +42,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/MetamorpheusToMSstatsFormat.Rd
+++ b/man/MetamorpheusToMSstatsFormat.Rd
@@ -39,11 +39,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/MetamorpheusToMSstatsFormat.Rd
+++ b/man/MetamorpheusToMSstatsFormat.Rd
@@ -36,7 +36,14 @@ We assume to use unique peptide for each protein.}
 
 \item{removeProtein_with1Feature}{TRUE will remove the proteins which have only 1 feature, which is the combination of peptide, precursor charge, fragment and charge. FALSE is default.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/OpenMStoMSstatsFormat.Rd
+++ b/man/OpenMStoMSstatsFormat.Rd
@@ -31,7 +31,14 @@ We assume to use unique peptide for each protein.}
 
 \item{removeProtein_with1Feature}{TRUE will remove the proteins which have only 1 feature, which is the combination of peptide, precursor charge, fragment and charge. FALSE is default.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/OpenMStoMSstatsFormat.Rd
+++ b/man/OpenMStoMSstatsFormat.Rd
@@ -34,11 +34,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/OpenSWATHtoMSstatsFormat.Rd
+++ b/man/OpenSWATHtoMSstatsFormat.Rd
@@ -37,7 +37,14 @@ We assume to use unique peptide for each protein.}
 
 \item{removeProtein_with1Feature}{TRUE will remove the proteins which have only 1 feature, which is the combination of peptide, precursor charge, fragment and charge. FALSE is default.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/OpenSWATHtoMSstatsFormat.Rd
+++ b/man/OpenSWATHtoMSstatsFormat.Rd
@@ -40,11 +40,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/PDtoMSstatsFormat.Rd
+++ b/man/PDtoMSstatsFormat.Rd
@@ -37,11 +37,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{removeFewMeasurements}{TRUE (default) will remove the features that have 1 or 2 measurements across runs.}
 

--- a/man/PDtoMSstatsFormat.Rd
+++ b/man/PDtoMSstatsFormat.Rd
@@ -34,7 +34,14 @@ Run information. 'Run' will be matched with 'Spectrum.File'.}
 \item{useUniquePeptide}{TRUE (default) removes peptides that are assigned for more than one proteins.
 We assume to use unique peptide for each protein.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{removeFewMeasurements}{TRUE (default) will remove the features that have 1 or 2 measurements across runs.}
 

--- a/man/PDtoMSstatsTMTFormat.Rd
+++ b/man/PDtoMSstatsTMTFormat.Rd
@@ -40,11 +40,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/PDtoMSstatsTMTFormat.Rd
+++ b/man/PDtoMSstatsTMTFormat.Rd
@@ -37,7 +37,14 @@ We assume to use unique peptide for each protein.}
 
 \item{rmProtein_with1Feature}{TRUE will remove the proteins which have only 1 peptide and charge. Default is FALSE.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/PhilosophertoMSstatsTMTFormat.Rd
+++ b/man/PhilosophertoMSstatsTMTFormat.Rd
@@ -53,11 +53,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/PhilosophertoMSstatsTMTFormat.Rd
+++ b/man/PhilosophertoMSstatsTMTFormat.Rd
@@ -50,7 +50,14 @@ We assume to use unique peptide for each protein.}
 
 \item{rmProtein_with1Feature}{TRUE will remove the proteins which have only 1 peptide and charge. Default is FALSE.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/ProgenesistoMSstatsFormat.Rd
+++ b/man/ProgenesistoMSstatsFormat.Rd
@@ -27,7 +27,14 @@ ProgenesistoMSstatsFormat(
 \item{useUniquePeptide}{TRUE (default) removes peptides that are assigned for more than one proteins.
 We assume to use unique peptide for each protein.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{removeFewMeasurements}{TRUE (default) will remove the features that have 1 or 2 measurements across runs.}
 

--- a/man/ProgenesistoMSstatsFormat.Rd
+++ b/man/ProgenesistoMSstatsFormat.Rd
@@ -30,11 +30,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{removeFewMeasurements}{TRUE (default) will remove the features that have 1 or 2 measurements across runs.}
 

--- a/man/ProteinProspectortoMSstatsTMTFormat.Rd
+++ b/man/ProteinProspectortoMSstatsTMTFormat.Rd
@@ -35,11 +35,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/ProteinProspectortoMSstatsTMTFormat.Rd
+++ b/man/ProteinProspectortoMSstatsTMTFormat.Rd
@@ -32,7 +32,14 @@ We assume to use unique peptide for each protein.}
 
 \item{removeProtein_with1Feature}{TRUE will remove the proteins which have only 1 feature, which is the combination of peptide, precursor charge, fragment and charge. FALSE is default.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/SpectroMinetoMSstatsTMTFormat.Rd
+++ b/man/SpectroMinetoMSstatsTMTFormat.Rd
@@ -39,11 +39,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/SpectroMinetoMSstatsTMTFormat.Rd
+++ b/man/SpectroMinetoMSstatsTMTFormat.Rd
@@ -36,7 +36,14 @@ We assume to use unique peptide for each protein.}
 
 \item{rmProtein_with1Feature}{TRUE will remove the proteins which have only 1 peptide and charge. Defaut is FALSE.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}

--- a/man/SpectronauttoMSstatsFormat.Rd
+++ b/man/SpectronauttoMSstatsFormat.Rd
@@ -75,7 +75,14 @@ We assume to use unique peptide for each protein.}
 
 \item{removeProtein_with1Feature}{TRUE will remove the proteins which have only 1 feature, which is the combination of peptide, precursor charge, fragment and charge. FALSE is default.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{calculateAnomalyScores}{Default is FALSE. If TRUE, will run anomaly detection model and calculate anomaly scores for each feature. Used downstream to weigh measurements in differential analysis.}
 

--- a/man/SpectronauttoMSstatsFormat.Rd
+++ b/man/SpectronauttoMSstatsFormat.Rd
@@ -78,11 +78,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{calculateAnomalyScores}{Default is FALSE. If TRUE, will run anomaly detection model and calculate anomaly scores for each feature. Used downstream to weigh measurements in differential analysis.}
 

--- a/man/dot-getFullDesign.Rd
+++ b/man/dot-getFullDesign.Rd
@@ -13,12 +13,12 @@
 \code{feature_col} and \code{measurement_col} will be created within each unique value
 of this column}
 
-\item{is_tmt}{if TRUE, data will be treated as coming from TMT experiment.}
+\item{feature_col}{name of the column that labels features}
 
-\item{`feature_col`}{name of the column that labels features}
-
-\item{`measurement_col`}{name of a column with measurement labels - Runs in
+\item{measurement_col}{name of a column with measurement labels - Runs in
 label-free case, Channels in TMT case.}
+
+\item{is_tmt}{if TRUE, data will be treated as coming from TMT experiment.}
 }
 \value{
 data.table

--- a/man/dot-sharedParametersAmongConverters.Rd
+++ b/man/dot-sharedParametersAmongConverters.Rd
@@ -12,7 +12,14 @@
 \item{useUniquePeptide}{TRUE (default) removes peptides that are assigned for more than one proteins.
 We assume to use unique peptide for each protein.}
 
-\item{summaryforMultipleRows}{max or sum - when there are multiple measurements for certain feature and certain run, use highest or sum of multiple intensities. Default is max for label-free converters and sum for TMT converters.}
+\item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
+the same feature within a single MS run (duplicate PSMs), use the
+highest (max) or sum of the duplicate intensities. Default is max for
+label-free converters and sum for TMT converters. This parameter does
+not control collapsing across fractions of the same biological mixture;
+fraction handling is performed separately by \code{MSstatsBalancedDesign()}
+(see the "Fractions and balanced design" section of the data format
+vignette).}
 
 \item{removeProtein_with1Feature}{TRUE will remove the proteins which have only 1 feature, which is the combination of peptide, precursor charge, fragment and charge. FALSE is default.}
 

--- a/man/dot-sharedParametersAmongConverters.Rd
+++ b/man/dot-sharedParametersAmongConverters.Rd
@@ -15,11 +15,8 @@ We assume to use unique peptide for each protein.}
 \item{summaryforMultipleRows}{max or sum - when multiple PSMs identify
 the same feature within a single MS run (duplicate PSMs), use the
 highest (max) or sum of the duplicate intensities. Default is max for
-label-free converters and sum for TMT converters. This parameter does
-not control collapsing across fractions of the same biological mixture;
-fraction handling is performed separately by \code{MSstatsBalancedDesign()}
-(see the "Fractions and balanced design" section of the data format
-vignette).}
+label-free converters and sum for TMT converters. Note that this parameter
+does NOT control collapsing across fractions of the same biological mixture.}
 
 \item{removeProtein_with1Feature}{TRUE will remove the proteins which have only 1 feature, which is the combination of peptide, precursor charge, fragment and charge. FALSE is default.}
 

--- a/vignettes/msstats_data_format.Rmd
+++ b/vignettes/msstats_data_format.Rmd
@@ -304,13 +304,37 @@ should consists of elements named
 
 # Fractions and balanced design
 
-Finally, after preprocessing, `MSstatsBalancedDesign` function can be applied to 
-handle fractions and create balanced design.
-For label-free and SRM data, it means that fractionation or technical replicates will be detected if these information is not provided. Features measured in multiple fractions (overlapped) will be assigned to a unique fraction. Then, the data will be adjusted so that within each fraction, every feature has a row for certain run. If the intensity value is missing, it will be denoted by `NA`.
+Finally, after preprocessing, the `MSstatsBalancedDesign` function can be
+applied to handle fractions and create a balanced design.
 
-For TMT data, a unique fraction will be selected for each overlapped feature and the 
-data will adjusted so that within each run, every feature has a row for each channel.
-If the intensity is missing for a channel, it will be denoted by `NA`.
+For label-free and SRM data, fractionation or technical replicates are
+detected if this information is not provided. Features that overlap
+across multiple fractions of the same sample are assigned to a single
+fraction by the following rule: for each feature, the fraction with the
+**largest number of MS runs containing a non-missing measurement** is
+kept. If multiple fractions tie on that count, the tie is broken by
+choosing the fraction with the **highest mean intensity**. The
+remaining fractions' rows for that feature are dropped. The data are
+then adjusted so that within each fraction, every feature has a row
+for each run. If the intensity value is missing, it is denoted by `NA`.
+
+For TMT data, a unique fraction is selected for each overlapped feature
+using a different cascade of criteria, applied in order until the
+overlap is resolved: the fraction with the **highest mean intensity**
+across channels is tried first, then the **highest sum**, then the
+**highest single intensity** (`max`). If features still overlap after
+all three passes, their intensities are averaged across fractions as a
+final fallback. After fraction selection, the data are adjusted so
+that within each run, every feature has a row for each channel. If
+the intensity is missing for a channel, it is denoted by `NA`.
+
+These two rules differ by design: the label-free path optimizes for
+the fraction with the most observations of the feature, while the TMT
+path optimizes for the fraction with the strongest signal. Note also
+that this fraction-collapsing logic is distinct from the
+`summaryforMultipleRows` argument on each converter, which only
+combines duplicate PSMs identifying the same feature within a single
+MS run.
 
 ```{r }
 maxquant_balanced = MSstatsBalancedDesign(maxquant_processed, feature_columns)

--- a/vignettes/msstats_data_format.Rmd
+++ b/vignettes/msstats_data_format.Rmd
@@ -307,7 +307,7 @@ should consists of elements named
 Finally, after preprocessing, the `MSstatsBalancedDesign` function can be
 applied to handle fractions and create a balanced design.
 
-For label-free and SRM data, fractionation or technical replicates are
+For label-free data, fractionation or technical replicates are
 detected if this information is not provided. Features that overlap
 across multiple fractions of the same sample are assigned to a single
 fraction by the following rule: for each feature, the fraction with the
@@ -319,19 +319,11 @@ then adjusted so that within each fraction, every feature has a row
 for each run. If the intensity value is missing, it is denoted by `NA`.
 
 For TMT data, a unique fraction is selected for each overlapped feature
-using a different cascade of criteria, applied in order until the
-overlap is resolved: the fraction with the **highest mean intensity**
-across channels is tried first, then the **highest sum**, then the
-**highest single intensity** (`max`). If features still overlap after
-all three passes, their intensities are averaged across fractions as a
-final fallback. After fraction selection, the data are adjusted so
+as well. After fraction selection, the data are adjusted so
 that within each run, every feature has a row for each channel. If
 the intensity is missing for a channel, it is denoted by `NA`.
 
-These two rules differ by design: the label-free path optimizes for
-the fraction with the most observations of the feature, while the TMT
-path optimizes for the fraction with the strongest signal. Note also
-that this fraction-collapsing logic is distinct from the
+Note also that this fraction-collapsing logic is distinct from the
 `summaryforMultipleRows` argument on each converter, which only
 combines duplicate PSMs identifying the same feature within a single
 MS run.


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

This PR addresses documentation inconsistencies and clarity issues in the MSstatsConvert package, particularly around the `summaryforMultipleRows` parameter used across multiple converter functions. Users were confused about the scope of this parameter—specifically, whether it controlled aggregation across fractions of the same biological mixture. The PR clarifies that this parameter only applies to handling duplicate PSMs (peptide-spectrum matches) within a single MS run, and explicitly states that it does NOT control collapsing across fractions. The PR also updates the roxygen2 configuration and improves the vignette explanation of fraction handling.

## Detailed Changes

### Package Metadata
- Updated `DESCRIPTION` file: removed `RoxygenNote: 7.3.3` field and added `Config/roxygen2/version: 8.0.0` to reflect roxygen2 configuration version change
- Added Anthony Wu (wu.anthon@northeastern.edu) to the package authors list in `man/MSstatsConvert.Rd`

### Documentation Parameter Clarifications
Expanded the `summaryforMultipleRows` argument documentation across 19 converter function man pages to consistently clarify:
- The parameter applies to **duplicate PSMs within a single MS run** (not across fractions)
- Behavior options: either use the highest intensity (`max`) or sum of duplicate intensities
- Default behavior differs by converter type: `max` for label-free converters, `sum` for TMT converters
- Explicit statement that the parameter does **not** control collapsing across fractions of the same biological mixture

**Affected functions:**
- `DIAUmpiretoMSstatsFormat`
- `FragPipetoMSstatsFormat`
- `MaxQtoMSstatsFormat`
- `MaxQtoMSstatsTMTFormat`
- `MetamorpheusToMSstatsFormat`
- `OpenMStoMSstatsFormat`
- `OpenSWATHtoMSstatsFormat`
- `PDtoMSstatsFormat`
- `PDtoMSstatsTMTFormat`
- `PhilosophertoMSstatsTMTFormat`
- `ProgenesistoMSstatsFormat`
- `ProteinProspectortoMSstatsTMTFormat`
- `SpectroMinetoMSstatsTMTFormat`
- `SpectronauttoMSstatsFormat`
- `.sharedParametersAmongConverters` (internal helper)

### Internal Documentation Updates
- Updated roxygen documentation in `R/utils_documentation.R` for the `.sharedParametersAmongConverters()` function with the same parameter clarifications
- Updated `.getFullDesign.Rd` man page with minor formatting adjustments (reordered and reformatted `feature_col` and `measurement_col` argument entries)

### Vignette Updates
- Rewrote the "Fractions and balanced design" section in `vignettes/msstats_data_format.Rmd` to:
  - Explicitly describe how `MSstatsBalancedDesign` selects a single fraction for overlapped features in label-free/SRM data (using largest number of non-missing MS runs; ties broken by highest mean intensity)
  - Clarify how rows are adjusted to ensure each feature has entries for every run/channel within selected fractions
  - Document how missing intensities are represented as `NA`
  - Add clarification distinguishing fraction-collapsing logic from the `summaryforMultipleRows` converter parameter

## Unit Tests

No unit tests were added or modified in this pull request. This is a documentation-only release.

## Coding Guidelines

According to the project's CONTRIBUTING.md guidelines, all changes appropriately:
- Modified roxygen2 documentation in `.R` files rather than directly editing `.Rd` files (following contribution guidelines for documentation updates)
- Used roxygen2 and R Markdown for documentation as specified in the project standards
- Maintained consistency with the existing documentation style across all converter functions

**Note:** The PR does not appear to include updates to `NEWS.md` or package version bump, which are typically required according to the contribution guidelines before merging. These items may need to be addressed before final approval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vitek-Lab/MSstatsConvert/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->