### PR TITLE
fix(spectronaut): Enable Fraction column to be processed

### DIFF
--- a/R/clean_Spectronaut.R
+++ b/R/clean_Spectronaut.R
@@ -8,7 +8,7 @@
                                 anomalyModelFeatures,
                                 peptideSequenceColumn = "EG.ModifiedSequence",
                                 heavyLabels = NULL) {
-  FFrgLossType = FExcludedFromQuantification = NULL
+  FFrgLossType = FExcludedFromQuantification = Fraction = NULL
 
   spec_input = getInputFile(msstats_object, "input")
   .validateSpectronautInput(spec_input, peptideSequenceColumn)
@@ -46,6 +46,10 @@
       "ProductCharge", "Run", "Intensity", "Condition", "BioReplicate",
       "Fraction"),
     skip_absent = TRUE)
+
+  if ("Fraction" %in% colnames(spec_input)) {
+    spec_input[is.na(Fraction), Fraction := 1]
+  }
 
   spec_input = .assignSpectronautIsotopeLabelType(
     spec_input, heavyLabels)

--- a/R/clean_Spectronaut.R
+++ b/R/clean_Spectronaut.R
@@ -48,7 +48,15 @@
     skip_absent = TRUE)
 
   if ("Fraction" %in% colnames(spec_input)) {
-    spec_input[is.na(Fraction), Fraction := 1]
+    n_missing_fraction = sum(is.na(spec_input$Fraction))
+    if (n_missing_fraction > 0) {
+      msg = paste("**", n_missing_fraction,
+                  "row(s) have missing (NA) values in the Fraction column.",
+                  "These will be assigned to Fraction 1.")
+      getOption("MSstatsLog")("WARN", msg)
+      getOption("MSstatsMsg")("WARN", msg)
+      spec_input[is.na(Fraction), Fraction := 1]
+    }
   }
 
   spec_input = .assignSpectronautIsotopeLabelType(

--- a/R/clean_Spectronaut.R
+++ b/R/clean_Spectronaut.R
@@ -29,8 +29,8 @@
 
   cols = c(protein_col, peptide_col, "FGCharge", "FFrgIon",
            f_charge_col, "RFileName", "RCondition", "RReplicate",
-           "EGQvalue", pg_qval_col, interference_col, exclude_col,
-           intensity_col)
+           "RFraction", "EGQvalue", pg_qval_col, interference_col,
+           exclude_col, intensity_col)
   if (calculateAnomalyScores){
     cols = c(cols, anomalyModelFeatures)
   }
@@ -41,9 +41,10 @@
     spec_input,
     c(protein_col, peptide_col, "FGCharge", "FFrgIon",
       f_charge_col, "RFileName", intensity_col,
-      "RCondition", "RReplicate"),
+      "RCondition", "RReplicate", "RFraction"),
     c("ProteinName", "PeptideSequence", "PrecursorCharge", "FragmentIon",
-      "ProductCharge", "Run", "Intensity", "Condition", "BioReplicate"),
+      "ProductCharge", "Run", "Intensity", "Condition", "BioReplicate",
+      "Fraction"),
     skip_absent = TRUE)
 
   spec_input = .assignSpectronautIsotopeLabelType(

--- a/inst/tinytest/test_clean_Spectronaut.R
+++ b/inst/tinytest/test_clean_Spectronaut.R
@@ -9,10 +9,8 @@ output = MSstatsConvert:::.cleanRawSpectronaut(msstats_input, intensity = 'FG.MS
                                     calculateAnomalyScores = FALSE, 
                                     anomalyModelFeatures = c())
 expect_true(all(output$Intensity == 100000))
-# When R.Fraction is absent, no Fraction column is added (prior behavior)
 expect_false("Fraction" %in% colnames(output))
 
-# R.Fraction is transferred and renamed to Fraction when present
 spectronaut_frac = data.table::copy(spectronaut_raw)
 spectronaut_frac$R.Fraction = 2L
 msstats_frac = MSstatsConvert::MSstatsImport(
@@ -24,7 +22,6 @@ expect_true("Fraction" %in% colnames(output_frac))
 expect_false("RFraction" %in% colnames(output_frac))
 expect_true(all(output_frac$Fraction == 2L))
 
-# NA values in R.Fraction are replaced with 1
 spectronaut_frac_na = data.table::copy(spectronaut_raw)
 spectronaut_frac_na$R.Fraction = NA_integer_
 msstats_frac_na = MSstatsConvert::MSstatsImport(

--- a/inst/tinytest/test_clean_Spectronaut.R
+++ b/inst/tinytest/test_clean_Spectronaut.R
@@ -24,6 +24,18 @@ expect_true("Fraction" %in% colnames(output_frac))
 expect_false("RFraction" %in% colnames(output_frac))
 expect_true(all(output_frac$Fraction == 2L))
 
+# NA values in R.Fraction are replaced with 1
+spectronaut_frac_na = data.table::copy(spectronaut_raw)
+spectronaut_frac_na$R.Fraction = NA_integer_
+msstats_frac_na = MSstatsConvert::MSstatsImport(
+    list(input = spectronaut_frac_na), "MSstats", "Spectronaut")
+output_frac_na = MSstatsConvert:::.cleanRawSpectronaut(msstats_frac_na, intensity = 'FG.MS1Quantity',
+                                    calculateAnomalyScores = FALSE,
+                                    anomalyModelFeatures = c())
+expect_true("Fraction" %in% colnames(output_frac_na))
+expect_false(any(is.na(output_frac_na$Fraction)))
+expect_true(all(output_frac_na$Fraction == 1))
+
 expect_error(MSstatsConvert:::.cleanRawSpectronaut(msstats_input, intensity = 'invalid',
                                                    calculateAnomalyScores = FALSE,
                                                    anomalyModelFeatures = c()),

--- a/inst/tinytest/test_clean_Spectronaut.R
+++ b/inst/tinytest/test_clean_Spectronaut.R
@@ -9,6 +9,20 @@ output = MSstatsConvert:::.cleanRawSpectronaut(msstats_input, intensity = 'FG.MS
                                     calculateAnomalyScores = FALSE, 
                                     anomalyModelFeatures = c())
 expect_true(all(output$Intensity == 100000))
+# When R.Fraction is absent, no Fraction column is added (prior behavior)
+expect_false("Fraction" %in% colnames(output))
+
+# R.Fraction is transferred and renamed to Fraction when present
+spectronaut_frac = data.table::copy(spectronaut_raw)
+spectronaut_frac$R.Fraction = 2L
+msstats_frac = MSstatsConvert::MSstatsImport(
+    list(input = spectronaut_frac), "MSstats", "Spectronaut")
+output_frac = MSstatsConvert:::.cleanRawSpectronaut(msstats_frac, intensity = 'FG.MS1Quantity',
+                                    calculateAnomalyScores = FALSE,
+                                    anomalyModelFeatures = c())
+expect_true("Fraction" %in% colnames(output_frac))
+expect_false("RFraction" %in% colnames(output_frac))
+expect_true(all(output_frac$Fraction == 2L))
 
 expect_error(MSstatsConvert:::.cleanRawSpectronaut(msstats_input, intensity = 'invalid',
                                                    calculateAnomalyScores = FALSE,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

Spectronaut experimental files include an `RFraction` column that represents sample fractionation information, but the `.cleanRawSpectronaut()` function was not processing this column. This fix enables the function to properly recognize, extract, and rename the `RFraction` column from the input data to align with the MSstats output schema, where it is expected as the `Fraction` field.

## Changes

- **Column Selection Enhancement**: Added `"RFraction"` to the list of columns selected from the raw Spectronaut input (line 32 in `clean_Spectronaut.R`)

- **Column Renaming Mapping**: Updated the `data.table::setnames()` call to include a mapping from `"RFraction"` (source) to `"Fraction"` (output schema name) (line 44-47 in `clean_Spectronaut.R`)

- **Graceful Handling of Missing Column**: Added `skip_absent = TRUE` parameter to the `setnames()` function to ensure the function continues to work correctly when the `RFraction` column is absent from the input, maintaining backward compatibility with existing Spectronaut files that don't include fractionation information

## Unit Tests

- **Backward Compatibility Test**: Verifies that when `R.Fraction` is absent from the input data, no `Fraction` column is added to the output, preserving existing behavior (lines 12-13 in `test_clean_Spectronaut.R`)

- **RFraction Transfer Test**: Confirms that when `R.Fraction` is present in the input, it is properly transferred to the output as the `Fraction` column with the correct values (lines 15-25 in `test_clean_Spectronaut.R`)

- **Column Naming Verification**: Asserts that the intermediate column name `RFraction` does not appear in the output (only the renamed `Fraction` column is present), ensuring correct schema compliance (line 24 in `test_clean_Spectronaut.R`)

## Code Guidelines

No violations identified. The implementation follows the existing code patterns in the repository, uses appropriate R/data.table idioms, and maintains consistency with how other optional columns are handled in the cleaning pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->